### PR TITLE
fix discord invitation links with non-expiring ones

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -38,8 +38,8 @@ libp2p_technical = "https://github.com/libp2p/libp2p?tab=readme-ov-file#disussio
 # chat rooms
 slack_community = "https://filecoinproject.slack.com/archives/C06HV0D00E5"
 slack_implementers = "https://filecoinproject.slack.com/archives/C03K82MU486"
-discord_community = "https://discord.gg/9R7uhF5D"
-discord_implementers = "https://discord.gg/2FPVa6Xy"
+discord_community = "https://discord.gg/ehaey3C733"
+discord_implementers = "https://discord.gg/Ae4TbahHaT"
 telegram_community = "https://t.me/libp2p_community/11"
 telegram_implementers =  "https://t.me/libp2p_community/5"
 matrix_community = "https://matrix.to/#/#libp2p-community:matrix.org"


### PR DESCRIPTION
This updates the discord chat links to ones that will never expire.