### PR TITLE
fix topbar links until migrated

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,9 +25,9 @@ github = "https://github.com/libp2p/libp2p"
 implementations = "https://github.com/libp2p/libp2p?tab=readme-ov-file#implementations"
 site_repo = "https://github.com/libp2p/website"
 specs_repo = "https://github.com/libp2p/specs"
-docs_repo = "https://libp2p.io/docs"
-blog_url = "https://libp2p.io/blog"
-connectivity_url = "https://libp2p.io/connectivity"
+docs_repo = "https://docs.libp2p.io"
+blog_url = "https://blog.libp2p.io"
+connectivity_url = "https://connectivity.libp2p.io"
 
 # discussion forums
 libp2p_community = "https://discuss.libp2p.io"


### PR DESCRIPTION
Put back the topbar links until those sites are migrated.

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
